### PR TITLE
Fix replace operator handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,11 +144,11 @@ func getPackages(keepGoing bool, numJobs int, prevDeps map[string]*Package) ([]*
 			"--fetch-submodules",
 			"--url", repoRoot.Repo,
 			"--rev", entry.rev).Output()
-		fmt.Println(fmt.Sprintf("Finished fetching %s", goPackagePath))
-
 		if err != nil {
 			return nil, wrapError(err)
 		}
+		fmt.Println(fmt.Sprintf("Finished fetching %s", goPackagePath))
+
 		var resp map[string]interface{}
 		if err := json.Unmarshal(jsonOut, &resp); err != nil {
 			return nil, wrapError(err)

--- a/main.go
+++ b/main.go
@@ -63,10 +63,15 @@ func getModules() ([]*modEntry, error) {
 		return nil, err
 	}
 
+	type goModReplacement struct {
+		Version string
+	}
+
 	type goMod struct {
 		Path    string
 		Main    bool
 		Version string
+		Replace *goModReplacement
 	}
 
 	var mods []goMod
@@ -77,6 +82,10 @@ func getModules() ([]*modEntry, error) {
 			break
 		} else if err != nil {
 			return nil, err
+		}
+
+		if mod.Replace != nil {
+			mod.Version = mod.Replace.Version
 		}
 
 		if !mod.Main {

--- a/tests/test_replace_version/expected.nix
+++ b/tests/test_replace_version/expected.nix
@@ -1,0 +1,21 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/coreos/go-systemd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-systemd";
+      rev = "v22.0.0";
+      sha256 = "0p4sb2fxxm2j1xny2l4fkq4kwj74plvh600gih8nyniqzannhrdx";
+    };
+  }
+  {
+    goPackagePath = "github.com/godbus/dbus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/godbus/dbus";
+      rev = "v5.0.3";
+      sha256 = "1bkc904073k807yxg6mvqaxrr6ammmhginr9p54jfb55mz3hfw3s";
+    };
+  }
+]

--- a/tests/test_replace_version/go.mod
+++ b/tests/test_replace_version/go.mod
@@ -1,0 +1,5 @@
+module testmodule
+
+require github.com/coreos/go-systemd v0.0.0-00010101000000-000000000000
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.0.0

--- a/tests/test_replace_version/go.sum
+++ b/tests/test_replace_version/go.sum
@@ -1,0 +1,2 @@
+github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
+github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=


### PR DESCRIPTION
This PR addresses two issues:
1) Misleading log message - saying that download succeeded and then failing immediately after it isn't... nice.
2) #22 