### PR TITLE
Fix replace handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,11 +144,11 @@ func getPackages(keepGoing bool, numJobs int, prevDeps map[string]*Package) ([]*
 			"--fetch-submodules",
 			"--url", repoRoot.Repo,
 			"--rev", entry.rev).Output()
-		fmt.Println(fmt.Sprintf("Finished fetching %s", goPackagePath))
-
 		if err != nil {
 			return nil, wrapError(err)
 		}
+		fmt.Println(fmt.Sprintf("Finished fetching %s", goPackagePath))
+
 		var resp map[string]interface{}
 		if err := json.Unmarshal(jsonOut, &resp); err != nil {
 			return nil, wrapError(err)

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func getModules() ([]*modEntry, error) {
 	commitRevV3 := regexp.MustCompile(`^(v\d+\.\d+\.\d+)\+incompatible$`)
 
 	var stderr bytes.Buffer
-	cmd := exec.Command("go", "list", "-json", "-m", "all")
+	cmd := exec.Command("go", "list", "-mod", "mod", "-json", "-m", "all")
 	cmd.Stderr = &stderr
 	cmd.Env = append(os.Environ(),
 		"GO111MODULE=on",

--- a/main.go
+++ b/main.go
@@ -63,10 +63,15 @@ func getModules() ([]*modEntry, error) {
 		return nil, err
 	}
 
+	type goModReplacement struct {
+		Version string
+	}
+
 	type goMod struct {
 		Path    string
 		Main    bool
 		Version string
+		Replace *goModReplacement
 	}
 
 	var mods []goMod
@@ -77,6 +82,10 @@ func getModules() ([]*modEntry, error) {
 			break
 		} else if err != nil {
 			return nil, err
+		}
+
+		if mod.Replace != nil {
+			mod.Version = mod.Replace.Version
 		}
 
 		if !mod.Main {

--- a/main.go
+++ b/main.go
@@ -27,8 +27,9 @@ type PackageResult struct {
 }
 
 type modEntry struct {
-	importPath string
-	rev        string
+	importPath  string
+	replacePath string
+	rev         string
 }
 
 const depNixFormat = `  {
@@ -64,6 +65,7 @@ func getModules() ([]*modEntry, error) {
 	}
 
 	type goModReplacement struct {
+		Path    string
 		Version string
 	}
 
@@ -106,10 +108,15 @@ func getModules() ([]*modEntry, error) {
 		} else if commitRevV3.MatchString(rev) {
 			rev = commitRevV3.FindAllStringSubmatch(rev, -1)[0][1]
 		}
+		replacePath := mod.Path
+		if mod.Replace != nil {
+			replacePath = mod.Replace.Path
+		}
 		fmt.Println(fmt.Sprintf("goPackagePath %s has rev %s", mod.Path, rev))
 		entries = append(entries, &modEntry{
-			importPath: mod.Path,
-			rev:        rev,
+			replacePath: replacePath,
+			importPath:  mod.Path,
+			rev:         rev,
 		})
 	}
 
@@ -128,12 +135,19 @@ func getPackages(keepGoing bool, numJobs int, prevDeps map[string]*Package) ([]*
 		}
 
 		repoRoot, err := vcs.RepoRootForImportPath(
+			entry.replacePath,
+			false)
+		if err != nil {
+			return nil, wrapError(err)
+		}
+
+		importRoot, err := vcs.RepoRootForImportPath(
 			entry.importPath,
 			false)
 		if err != nil {
 			return nil, wrapError(err)
 		}
-		goPackagePath := repoRoot.Root
+		goPackagePath := importRoot.Root
 
 		if prevPkg, ok := prevDeps[goPackagePath]; ok {
 			if prevPkg.Rev == entry.rev {
@@ -169,7 +183,7 @@ func getPackages(keepGoing bool, numJobs int, prevDeps map[string]*Package) ([]*
 		}
 
 		return &Package{
-			GoPackagePath: repoRoot.Root,
+			GoPackagePath: goPackagePath,
 			URL:           repoRoot.Repo,
 			Rev:           entry.rev,
 			Sha256:        sha256,

--- a/tests/test_replace_url/expected.nix
+++ b/tests/test_replace_url/expected.nix
@@ -1,0 +1,21 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "golang.org/x/text";
+    fetch = {
+      type = "git";
+      url = "https://github.com/golang/text";
+      rev = "v0.3.2";
+      sha256 = "0flv9idw0jm5nm8lx25xqanbkqgfiym6619w575p7nrdh0riqwqh";
+    };
+  }
+  {
+    goPackagePath = "golang.org/x/tools";
+    fetch = {
+      type = "git";
+      url = "https://go.googlesource.com/tools";
+      rev = "90fa682c2a6e";
+      sha256 = "03ic2xsy51jw9749wl7gszdbz99iijbd2bckgygl6cm9w5m364ak";
+    };
+  }
+]

--- a/tests/test_replace_url/go.mod
+++ b/tests/test_replace_url/go.mod
@@ -1,0 +1,7 @@
+module testmodule
+
+go 1.11
+
+require golang.org/x/text v0.3.2
+
+replace golang.org/x/text => github.com/golang/text v0.3.2

--- a/tests/test_replace_url/go.sum
+++ b/tests/test_replace_url/go.sum
@@ -1,0 +1,3 @@
+github.com/golang/text v0.3.2 h1:vDAeTQXl8YUdGoj2vMsMnzHi1xMJJ9S7iwnTBFL/pkA=
+github.com/golang/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/tests/test_replace_url/main.go
+++ b/tests/test_replace_url/main.go
@@ -1,0 +1,6 @@
+package main
+
+import _ "golang.org/x/text"
+
+func main() {
+}

--- a/tests/test_replace_version/expected.nix
+++ b/tests/test_replace_version/expected.nix
@@ -1,0 +1,21 @@
+# file generated from go.mod using vgo2nix (https://github.com/adisbladis/vgo2nix)
+[
+  {
+    goPackagePath = "github.com/coreos/go-systemd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-systemd";
+      rev = "v22.0.0";
+      sha256 = "0p4sb2fxxm2j1xny2l4fkq4kwj74plvh600gih8nyniqzannhrdx";
+    };
+  }
+  {
+    goPackagePath = "github.com/godbus/dbus";
+    fetch = {
+      type = "git";
+      url = "https://github.com/godbus/dbus";
+      rev = "v5.0.3";
+      sha256 = "1bkc904073k807yxg6mvqaxrr6ammmhginr9p54jfb55mz3hfw3s";
+    };
+  }
+]

--- a/tests/test_replace_version/go.mod
+++ b/tests/test_replace_version/go.mod
@@ -1,0 +1,5 @@
+module testmodule
+
+require github.com/coreos/go-systemd v0.0.0-00010101000000-000000000000
+
+replace github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.0.0

--- a/tests/test_replace_version/go.sum
+++ b/tests/test_replace_version/go.sum
@@ -1,0 +1,2 @@
+github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
+github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=


### PR DESCRIPTION
This PR builds on https://github.com/adisbladis/vgo2nix/pull/27

I added a test for URL replacements based on how they are used elsewhere on github. Note that this URL replacement isn't useful, the backing git repositories are still the same, but it works fine as a test and is unlikely to break. Most real world examples involve pull requests that will eventually be deleted.

I then wrote URL replacement support which passes the tests. It's not a very elegant solution but it seems to work.