### PR TITLE
README.org: make the example more complete

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,10 +12,11 @@ vgo2nix
 
 This will write a file called =deps.nix= that is to be used together with an expression like
 #+begin_src nix
-{ buildGoPackage }:
+{ buildGoPackage, fetchFromGitHub }:
 buildGoPackage rec {
   name = "vgo2nix-${version}";
   version = "example";
+  goPackagePath = "...";  # Incomplete
   src = fetchFromGitHub { ... };  # Incomplete
   goDeps = ./deps.nix;
 }


### PR DESCRIPTION
`goPackagePath` seems to be required.
Added `fetchFromGitHub` to the dependencies as a convenience.