### PR TITLE
Change module name to reflect repo path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/adisbladis/vgo2nix
+module github.com/nix-community/vgo2nix
 
 go 1.14
 


### PR DESCRIPTION
This will allow the tool to be installed with "go install github.com/nix-community/vgo2nix" with Go Modules enabled.