### PR TITLE
Repo url edge case

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,6 +181,15 @@ func getPackages(keepGoing bool, numJobs int, prevDeps map[string]*Package) ([]*
 		// https://github.com/NixOS/nixpkgs/blob/8d8e56824de52a0c7a64d2ad2c4ed75ed85f446a/pkgs/development/go-modules/generic/default.nix#L54-L56
 		// and fetchgit's defaults:
 		// https://github.com/NixOS/nixpkgs/blob/8d8e56824de52a0c7a64d2ad2c4ed75ed85f446a/pkgs/build-support/fetchgit/default.nix#L15-L23
+		if !strings.HasPrefix(entry.repo, "http") {
+			entry.repo = "http://" + entry.repo
+		}
+
+		if _, err := exec.Command("git", "ls-remote", entry.repo).Output(); err != nil {
+			fmt.Printf("Repo %s not found. Trying with %s.git\n", entry.repo, entry.repo)
+			entry.repo = entry.repo + ".git"
+		}
+
 		jsonOut, err := exec.Command(
 			"nix-prefetch-git",
 			"--quiet",


### PR DESCRIPTION
I recently ran `vgo2nix` and I bumped into a git repository that could not be found:

```
goPackagePath sourcegraph.com/sqs/pbtypes has rev: v1.0.0, module:
Fetching git.apache.org/thrift.git git.apache.org/thrift
panic: Error processing import path "git.apache.org/thrift.git": nix-prefetch-git --fetch-submodules --no-deepClone --url git.apache.org/thrift --rev 2566ecd5d999 failed:
Initialized empty Git repository in /tmp/git-checkout-tmp-rj3jSzeX/thrift-2566ecd/.git/
fatal: 'git.apache.org/thrift' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: 'git.apache.org/thrift' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Unable to checkout 2566ecd5d999 from git.apache.org/thrift.


goroutine 1 [running]:
main.main()
        /build/source/main.go:291 +0x713
```

So I tested a few versions of this command used by vgo2nix here: https://github.com/nix-community/vgo2nix/blob/master/main.go#L185 and basically found that i needed to add an "https" prefix and ".git" suffix. This command worked for me:

```
nix-prefetch-git --fetch-submodules --no-deepClone --url https://git.apache.org/thrift.git --rev 2566ecd5d999
```

This led me to writing this patch which does the following:

1. Adds a Prefix of "http://" if "http" prefix is missing.
2. Checks whether the repository exists and if it doesn't it will append `.git` to the url and let the following command of `nix-prefetch-git` handle the error if the repository ACTUALLY doesn't exist.

Hopefully this is acceptable and I'm looking forward to your opinions.

EDIT:
I should probably change the second part since I'm incorrectly assuming that the error is due to a missing prefix to the url when it could be for example that git is not installed. I will fix this.